### PR TITLE
Fix sync-manifest to not rerun code collectors by default

### DIFF
--- a/sync-manifest/action.yml
+++ b/sync-manifest/action.yml
@@ -1,5 +1,5 @@
-name: Sync Lunar policy
-description: Instruct Lunar hub to pull manifest
+name: Sync Lunar manifest
+description: Instruct Lunar Hub to pull the latest manifest configuration
 author: Earthly technologies
 inputs:
   manifest-url:
@@ -15,10 +15,25 @@ inputs:
   hub-host:
     required: true
   hub-grpc-port:
-    default: 443
+    default: "443"
     required: false
   hub-http-port:
-    default: 443
+    default: "443"
+    required: false
+  rerun-code-collectors:
+    description: >
+      Rerun affected code collectors after pulling the manifest. Default: false.
+    default: "false"
+    required: false
+  include-pr-commits:
+    description: >
+      Include PR commits when rerunning code collectors. Only used when rerun-code-collectors is true.
+    default: "false"
+    required: false
+  pr-max-age-days:
+    description: >
+      Ignore PR commits older than this max (days). Only used when rerun-code-collectors is true.
+    default: "5"
     required: false
   log-level:
     description: >
@@ -33,19 +48,27 @@ runs:
       env:
         FORCE_COLOR: 1
       run: |
-        mkdir -p /tmp/lunar/bin
         curl -L https://github.com/earthly/lunar-dist/releases/download/${{ inputs.lunar-version }}/lunar-linux-amd64 -o /usr/local/bin/lunar
         chmod +x /usr/local/bin/lunar
-        echo "lunar downloaded to /tmp/lunar/bin/lunar";
+        echo "Lunar ${{ inputs.lunar-version }} installed"
       shell: bash
 
-    - name: Pull policy
+    - name: Pull manifest
       env:
         FORCE_COLOR: 1
         LUNAR_HUB_TOKEN: ${{ inputs.hub-token }}
         LUNAR_HUB_HOST: ${{ inputs.hub-host }}
         LUNAR_HUB_GRPC_PORT: ${{ inputs.hub-grpc-port }}
         LUNAR_HUB_HTTP_PORT: ${{ inputs.hub-http-port }}
-      run: lunar hub pull -r ${{ inputs.manifest-url }}
+        LUNAR_LOG_LEVEL: ${{ inputs.log-level }}
+      run: |
+        ARGS=""
+        if [ "${{ inputs.rerun-code-collectors }}" = "true" ]; then
+          ARGS="$ARGS -r"
+          if [ "${{ inputs.include-pr-commits }}" = "true" ]; then
+            ARGS="$ARGS --include-pr-commits"
+          fi
+          ARGS="$ARGS --pr-max-age-days ${{ inputs.pr-max-age-days }}"
+        fi
+        lunar hub pull $ARGS ${{ inputs.manifest-url }}
       shell: bash
-

--- a/sync-manifest/action.yml
+++ b/sync-manifest/action.yml
@@ -1,6 +1,6 @@
 name: Sync Lunar manifest
 description: Instruct Lunar Hub to pull the latest manifest configuration
-author: Earthly technologies
+author: Earthly Technologies
 inputs:
   manifest-url:
     description: >
@@ -62,13 +62,13 @@ runs:
         LUNAR_HUB_HTTP_PORT: ${{ inputs.hub-http-port }}
         LUNAR_LOG_LEVEL: ${{ inputs.log-level }}
       run: |
-        ARGS=""
+        ARGS=()
         if [ "${{ inputs.rerun-code-collectors }}" = "true" ]; then
-          ARGS="$ARGS -r"
+          ARGS+=("-r")
           if [ "${{ inputs.include-pr-commits }}" = "true" ]; then
-            ARGS="$ARGS --include-pr-commits"
+            ARGS+=("--include-pr-commits")
           fi
-          ARGS="$ARGS --pr-max-age-days ${{ inputs.pr-max-age-days }}"
+          ARGS+=("--pr-max-age-days" "${{ inputs.pr-max-age-days }}")
         fi
-        lunar hub pull $ARGS ${{ inputs.manifest-url }}
+        lunar hub pull "${ARGS[@]}" "${{ inputs.manifest-url }}"
       shell: bash


### PR DESCRIPTION
## Problem

The `sync-manifest` action was hardcoding the `-r` flag in the `lunar hub pull` call, which forces code collectors to rerun on every manifest sync. This contradicts the [CLI's documented behavior](https://docs-lunar.earthly.dev/lunar-cli/lunar-cli#lunar-hub-pull) where `--rerun-code-collectors` is opt-in (default: false).

## Changes

- **Remove hardcoded `-r` flag** — `lunar hub pull` now runs without rerunning code collectors by default, matching the CLI convention
- **Add `rerun-code-collectors` input** (default: `false`) — users can opt in explicitly
- **Add `include-pr-commits` input** (default: `false`) — exposes the CLI's `--include-pr-commits` flag
- **Add `pr-max-age-days` input** (default: `5`) — exposes the CLI's `--pr-max-age-days` flag
- **Pass `LUNAR_LOG_LEVEL` env var** — the `log-level` input was declared but never passed to the pull step
- **Fix naming** — action name changed from "Sync Lunar policy" to "Sync Lunar manifest"; step name from "Pull policy" to "Pull manifest"
- **Clean up download step** — remove unused `mkdir -p /tmp/lunar/bin`

## Impact

Existing users of `sync-manifest` who rely on code collectors being rerun automatically will need to add `rerun-code-collectors: true` to their workflow. This is a **breaking change** but aligns the action with the CLI's documented default behavior.

*This PR was generated by AI.* 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for manifest sync: rerun code collectors, include PR commits, and PR max-age days.
  * Improved logging via LUNAR_LOG_LEVEL.
  * Download/install message now shows versioned confirmation.

* **Updates**
  * Renamed step "Pull policy" to "Pull manifest".
  * Pull logic now respects the new inputs to conditionally include rerun/include-PR flags and PR age.
  * Default hub port inputs updated to "443".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->