### PR TITLE
Update lunar CLI version in attach action

### DIFF
--- a/attach/action.yml
+++ b/attach/action.yml
@@ -54,7 +54,7 @@ runs:
       run: |
         echo "pid $$ ppid $PPID"
         mkdir -p /tmp/lunar/bin
-        curl -L https://github.com/earthly/lunar-dist/releases/download/v1.0.0/lunar-linux-amd64 -o /tmp/lunar/bin/lunar
+        curl -L https://github.com/earthly/lunar-dist/releases/download/v1.1.1/lunar-linux-amd64 -o /tmp/lunar/bin/lunar
         chmod +x /tmp/lunar/bin/lunar;
         echo "lunar downloaded to /tmp/lunar/bin/lunar";
       shell: bash


### PR DESCRIPTION
## Summary
- Update lunar CLI version: v1.0.0 -> v1.1.1 (was very stale)

*This fix was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Lunar Linux binary version referenced in the GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->