### PR TITLE
chore: add lunar.yml (engineering.lunar.public)

### DIFF
--- a/lunar.yml
+++ b/lunar.yml
@@ -1,0 +1,11 @@
+# Earthly per-repo catalog file. Read by the lunar-yml cataloger in
+# earthly/lunar-internal-config to classify this repo and apply the
+# right collectors/policies via domain prefix matching.
+#
+# Schema: https://github.com/earthly/lunar-internal-config#per-repo-lunaryml
+
+domain: engineering.lunar.public
+codeowners:
+  - brandonSc
+
+description: Lunar GitHub Action — CI-side collectors for the Lunar Hub


### PR DESCRIPTION
Adds a top-level `lunar.yml` so the [lunar-yml cataloger](https://github.com/earthly/lunar-internal-config/tree/main/catalogers/lunar-yml) in `earthly/lunar-internal-config` classifies this repo and applies the right per-domain policies.

- **Domain**: `engineering.lunar.public`
- **Codeowners**: brandonSc

Coordinated rollout across 15 repos; see [earthly/lunar-internal-config](https://github.com/earthly/lunar-internal-config) for the convention. Per-domain policies (CODEOWNERS presence, no `:latest` Docker tags, branch protection basics, Linear tickets on private repos) are at `enforcement: report-pr`; everything else is `score` (observe-only).

_This PR was drafted by AI._